### PR TITLE
fix the bug about missing text of some sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,9 @@
 Input: a pdf file's full path.<br> 
 Return: a pyMuPDF file object, the full text of the pdf file, total pages of the pdf<br>
 
-- `processing_pdf.auto_find_toc`<br>
+- ```processing_pdf.auto_find_toc```<br>
+This function will get the PDF file's original table_of_content, do some cleanup to make it more neat. If the original table_of_content is missing, it will use RE mapping method to create one. However, user needs to check if the auto-generated toc is what they want. They could further customize it based on the generated template.
+The purpose to do cleanup on the original toc is that some contain whitespaces (\r, \n, extra \s) making the display ugly.
 Input: the pyMuPDF file object which returns from the above function `processing_pdf.open_file`<br>
 Return: a composite list structure. An example is like this:<br>
 ```
@@ -80,3 +82,4 @@ Return: a composite list structure. An example is like this:<br>
 1. bug fixing based on feedback
 2. Extract tables
 3. Image extraction bug: some overlapping images are extracted into separate files
+4. Further cleanup the Latex formula and diagrams

--- a/processing_pdf.ipynb
+++ b/processing_pdf.ipynb
@@ -35,14 +35,14 @@
           "name": "stderr",
           "output_type": "stream",
           "text": [
-            "[nltk_data] Downloading package stopwords to C:\\Users\\Wang\n",
-            "[nltk_data]     Zihan\\AppData\\Roaming\\nltk_data...\n",
+            "[nltk_data] Downloading package stopwords to\n",
+            "[nltk_data]     C:\\Users\\Claud\\AppData\\Roaming\\nltk_data...\n",
             "[nltk_data]   Package stopwords is already up-to-date!\n",
-            "[nltk_data] Downloading package punkt to C:\\Users\\Wang\n",
-            "[nltk_data]     Zihan\\AppData\\Roaming\\nltk_data...\n",
+            "[nltk_data] Downloading package punkt to\n",
+            "[nltk_data]     C:\\Users\\Claud\\AppData\\Roaming\\nltk_data...\n",
             "[nltk_data]   Package punkt is already up-to-date!\n",
-            "[nltk_data] Downloading package wordnet to C:\\Users\\Wang\n",
-            "[nltk_data]     Zihan\\AppData\\Roaming\\nltk_data...\n",
+            "[nltk_data] Downloading package wordnet to\n",
+            "[nltk_data]     C:\\Users\\Claud\\AppData\\Roaming\\nltk_data...\n",
             "[nltk_data]   Package wordnet is already up-to-date!\n"
           ]
         }
@@ -85,7 +85,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 5,
+      "execution_count": 69,
       "metadata": {},
       "outputs": [
         {
@@ -98,36 +98,13 @@
         {
           "data": {
             "text/plain": [
-              "[[1, '1 Introduction', 1],\n",
-              " [1, '2 Related Work', 2],\n",
-              " [1, '3 Method', 3],\n",
-              " [2, '3.1 Vision Transformer (ViT)', 3],\n",
-              " [2, '3.2 Fine-tuning and Higher Resolution', 4],\n",
-              " [1, '4 Experiments', 4],\n",
-              " [2, '4.1 Setup', 4],\n",
-              " [2, '4.2 Comparison to State of the Art', 5],\n",
-              " [2, '4.3 Pre-training Data Requirements', 6],\n",
-              " [2, '4.4 Scaling Study', 8],\n",
-              " [2, '4.5 Inspecting Vision Transformer', 8],\n",
-              " [2, '4.6 Self-supervision', 8],\n",
-              " [1, '5 Conclusion', 9],\n",
-              " [1, 'A Multihead Self-attention', 13],\n",
-              " [1, 'B Experiment details', 13],\n",
-              " [2, 'B.1 Training', 13],\n",
-              " [3, 'B.1.1 Fine-tuning', 13],\n",
-              " [3, 'B.1.2 Self-supervision', 14],\n",
-              " [1, 'C Additional Results', 14],\n",
-              " [1, 'D Additional Analyses', 15],\n",
-              " [2, 'D.1 SGD vs. Adam for ResNets', 15],\n",
-              " [2, 'D.2 Transformer shape', 16],\n",
-              " [2, 'D.3 Head Type and class token', 16],\n",
-              " [2, 'D.4 Positional Embedding', 17],\n",
-              " [2, 'D.5 Empirical Computational Costs', 18],\n",
-              " [2, 'D.6 Axial Attention', 19],\n",
-              " [2, 'D.7 Attention Distance', 20],\n",
-              " [2, 'D.8 Attention Maps', 20],\n",
-              " [2, 'D.9 ObjectNet Results', 20],\n",
-              " [2, 'D.10 VTAB Breakdown', 20]]"
+              "[[1, 'I Introduction', 1],\n",
+              " [1, 'II  Modeling', 2],\n",
+              " [2, 'A Assume f(t) proportional to (e+pe)', 3],\n",
+              " [2, 'B Assume f(t) proportional to e', 5],\n",
+              " [1, 'III Comparison with the early universe', 5],\n",
+              " [1, 'IV Summary', 6],\n",
+              " [1, ' References', 6]]"
             ]
           },
           "metadata": {},
@@ -137,26 +114,21 @@
       "source": [
         "# pdf_file =  \"An Empirical Survey on Long Document Summarization.pdf\"\n",
         "# pdf_file = \"1901.00009v1.pdf\"\n",
-        "# pdf_file = \"1901.00002v1.pdf\"\n",
+        "pdf_file = \"1901.00002v1.pdf\"\n",
         "# pdf_file = \"1901.00936v3.pdf\"\n",
-        "pdf_file = \"an image is worth 16 by 16 words.pdf\"\n",
+        "# pdf_file = \"an image is worth 16 by 16 words.pdf\"\n",
         "doc, total_text, total_pages = processing_pdf.open_file(project_data_path + \"/\" + pdf_file)\n",
-        "table_of_content = doc.get_toc()\n",
-        "print(\"Auto generated table of content:\")\n",
-        "display(table_of_content)\n",
         "\n",
-        "# some papers have not table of content\n",
-        "if len(table_of_content) == 0:\n",
-        "    print(\"***The paper has not table of content.*** Need to use regular expression to map table of content.\")\n",
-        "    table_of_content = processing_pdf.auto_find_toc(doc)\n",
-        "    print(\"Not satified the generated result or want to adjust? Build your own table of content by using this template:\")\n",
-        "    display(table_of_content)\n",
+        "# Use processing_pdf.auto_find_toc(), which will clean up the original toc\n",
+        "# table_of_content = doc.get_toc()\n",
+        "table_of_content = processing_pdf.auto_find_toc(doc)\n",
+        "display(table_of_content)\n",
         "\n"
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": 6,
+      "execution_count": 70,
       "metadata": {},
       "outputs": [
         {
@@ -164,16 +136,17 @@
           "output_type": "stream",
           "text": [
             "starting looking for all the sections according to the provided section title info...\n",
-            "save the dataframe to d:\\Start_Dec_19_2023\\application\\NUS Course\\Semester_1\\Neural Network and Deep Learning\\PDF_Conversion/processed/an image is worth 16 by 16 words.csv\n",
-            "save the dataframe to d:\\Start_Dec_19_2023\\application\\NUS Course\\Semester_1\\Neural Network and Deep Learning\\PDF_Conversion/processed/an image is worth 16 by 16 words.json\n",
+            "save the dataframe to d:\\Start_Dec_19_2023\\application\\NUS Course\\Semester_1\\Neural Network and Deep Learning\\PDF_Conversion/processed/1901.00002v1.csv\n",
+            "save the dataframe to d:\\Start_Dec_19_2023\\application\\NUS Course\\Semester_1\\Neural Network and Deep Learning\\PDF_Conversion/processed/1901.00002v1_meta.csv\n",
+            "save the dataframe to d:\\Start_Dec_19_2023\\application\\NUS Course\\Semester_1\\Neural Network and Deep Learning\\PDF_Conversion/processed/1901.00002v1.json\n",
             "\n",
-            "Title: AN IMAGE IS WORTH 16X16 WORDS:TRANSFORMERS FOR IMAGE RECOGNITION AT SCALE\n",
+            "Title: Black holes in the turbulence phase of viscous rip cosmology\n",
             "\n",
-            "Authors:Alexey Dosovitskiy∗,†, Lucas Beyer∗, Alexander Kolesnikov∗, Dirk Weissenborn∗,Xiaohua Zhai∗, Thomas Unterthiner, Mostafa Dehghani, Matthias Minderer,Georg Heigold, Sylvain Gelly, Jakob Uszkoreit, Neil Houlsby∗,†\n",
+            "Authors:Iver Brevik1 and Mubasher Jamil2\n",
             "\n",
-            "Other info: ∗equal technical contribution, †equal advisingGoogle Research, Brain Team{adosovitskiy, neilhoulsby}@google.com\n",
+            "Other info: \n",
             "\n",
-            "Abstract: While the Transformer architecture has become the de-facto standard for naturallanguage processing tasks, its applications to computer vision remain limited. Invision, attention is either applied in conjunction with convolutional networks, orused to replace certain components of convolutional networks while keeping theiroverall structure in place. We show that this reliance on CNNs is not necessaryand a pure transformer applied directly to sequences of image patches can performvery well on image classiﬁcation tasks. When pre-trained on large amounts ofdata and transferred to multiple mid-sized or small image recognition benchmarks(ImageNet, CIFAR-100, VTAB, etc.), Vision Transformer (ViT) attains excellentresults compared to state-of-the-art convolutional networks while requiring sub-stantially fewer computational resources to train.1\n"
+            "Abstract:1Department of Energy and Process Engineering, Norwegian University of Science and Technology, N-7491 Trondheim, Norway2Department of Mathematics, School of Natural Sciences (SNS),National University of Sciences and Technology (NUST), H-12, Islamabad, Pakistan(Dated: January 3, 2019) We study the phantom ﬂuid in the late universe, thus assuming the equation of state parameter wto be less than −1. The ﬂuid is assumed to consist of two components, one laminar component ρ andone turbulent component ρT , the latter set proportional to ρ as well as to the Hubble parameter, ρT =3τHρ with τ a positive constant associated with the turbulence. The effective energy density is takento be ρe = ρ + ρT , and the corresponding effective pressure is pe = wρe, with w constant. These basicassumptions lead to a Big Rip universe; the physical quantities diverging during a ﬁnite rip time ts.We then consider the mass accretion of a black hole in such a universe. The most natural assumptionof setting the rate dM/dt proportional to M 2 times the sum ρe+pe, leads to a negative mass accretion,where M(t) goes to zero linearly in (ts −t) near the singularity. The Hubble parameter diverges as(ts −t)−1, whereas ρe and pe diverge as (ts −t)−2. We also discuss other options and include, for thesake of comparison, some essential properties of mass accretion in the early (inﬂationary) universe. PACS numbers: 04.40.-b, 95.30.Sf, 98.62.Sb; Mathematics Subject Classiﬁcation 2010: 83F05 CosmologyKeywords: viscous universe, late universe, turbulent universe\n"
           ]
         }
       ],
@@ -241,7 +214,7 @@
       "name": "python",
       "nbconvert_exporter": "python",
       "pygments_lexer": "ipython3",
-      "version": "3.10.14"
+      "version": "3.11.4"
     }
   },
   "nbformat": 4,


### PR DESCRIPTION
1, Xi found a bug - on some files, the text on some sections are missing. The problem is caused by the mismatch table_of_content titles and titles of final output JSON. Since the original table of content might contain some extra white spaces, or \n, \r characters, When I create JSON file, I remove those characters, but the side effiect is to result in the mismatch titles of sections.

Solution is: when reading the table_of_content for the first time, do this clean-up job immediately, instead of waiting till the last step of outputting to JSON file.

I also updated Readme.md to reflect the change.